### PR TITLE
Refactor theme switching to use classList

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -8,6 +8,13 @@ function populateThemeDropdown() {
     { value: 'theme-autumn', label: 'Autumn' }
   ];
 
+  const themeClasses = ['theme-moss', 'theme-autumn'];
+
+  function applyTheme(theme) {
+    themeClasses.forEach((cls) => document.body.classList.remove(cls));
+    if (theme) document.body.classList.add(theme);
+  }
+
   themes.forEach(({ value, label }) => {
     const option = document.createElement('option');
     option.value = value;
@@ -16,12 +23,12 @@ function populateThemeDropdown() {
   });
 
   const savedTheme = localStorage.getItem('theme') || '';
-  document.body.className = savedTheme;
+  applyTheme(savedTheme);
   select.value = savedTheme;
 
   select.addEventListener('change', (e) => {
     const theme = e.target.value;
-    document.body.className = theme;
+    applyTheme(theme);
     localStorage.setItem('theme', theme);
   });
 }


### PR DESCRIPTION
## Summary
- preserve non-theme body classes by removing only known theme classes
- add helper for applying theme and track available themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a1f2aba0832b833134e9bce59ac3