### PR TITLE
Auto-detect theme classes from stylesheets

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1,23 +1,56 @@
+function getThemesFromStyleSheets() {
+  const themes = new Set();
+
+  function extract(rules) {
+    if (!rules) return;
+    for (const rule of Array.from(rules)) {
+      if (rule.selectorText) {
+        const matches = rule.selectorText.match(/body\.theme-[\w-]+/g);
+        if (matches) {
+          matches.forEach((m) => themes.add(m.replace('body.', '')));
+        }
+      }
+      if (rule.cssRules) {
+        extract(rule.cssRules);
+      }
+    }
+  }
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      extract(sheet.cssRules);
+    } catch (e) {
+      // Ignore cross-origin stylesheets
+    }
+  }
+
+  return Array.from(themes);
+}
+
 function populateThemeDropdown() {
   const select = document.getElementById('theme-select');
   if (!select) return;
 
-  const themes = [
-    { value: '', label: 'Default' },
-    { value: 'theme-moss', label: 'Moss' },
-    { value: 'theme-autumn', label: 'Autumn' }
-  ];
-
-  const themeClasses = ['theme-moss', 'theme-autumn'];
+  const themeClasses = getThemesFromStyleSheets();
 
   function applyTheme(theme) {
     themeClasses.forEach((cls) => document.body.classList.remove(cls));
     if (theme) document.body.classList.add(theme);
   }
 
-  themes.forEach(({ value, label }) => {
+  const defaultOption = document.createElement('option');
+  defaultOption.value = '';
+  defaultOption.textContent = 'Default';
+  select.appendChild(defaultOption);
+
+  themeClasses.forEach((cls) => {
     const option = document.createElement('option');
-    option.value = value;
+    option.value = cls;
+    const label = cls
+      .replace(/^theme-/, '')
+      .split('-')
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+      .join(' ');
     option.textContent = label;
     select.appendChild(option);
   });


### PR DESCRIPTION
## Summary
- Scan `document.styleSheets` to detect `body.theme-*` selectors
- Build theme dropdown dynamically and persist selection in `localStorage`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a2b18db4832b978a9b1d8ff92822