### PR TITLE
Delay theme dropdown initialization until stylesheets are ready

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -66,5 +66,9 @@ function populateThemeDropdown() {
   });
 }
 
-window.addEventListener('DOMContentLoaded', populateThemeDropdown);
+if (document.readyState === 'complete') {
+  populateThemeDropdown();
+} else {
+  window.addEventListener('load', populateThemeDropdown);
+}
 


### PR DESCRIPTION
## Summary
- Ensure theme dropdown initializes only after all stylesheets load
- Remove DOMContentLoaded handler and fallback to immediate run if document already complete

## Testing
- `node --version`
- `node --check theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6a4186dc8832b9ee25bbae9480c81