### PR TITLE
Reset theme preference when clearing save

### DIFF
--- a/game.js
+++ b/game.js
@@ -82,6 +82,16 @@ function clearSave() {
   localStorage.removeItem("prefs");
   localStorage.removeItem("qIndex");
   localStorage.removeItem("currentNode");
+  localStorage.removeItem("theme");
+  const select = document.getElementById("theme-select");
+  if (select) {
+    const themeClasses =
+      typeof getThemesFromStyleSheets === "function"
+        ? getThemesFromStyleSheets()
+        : [];
+    themeClasses.forEach(cls => document.body.classList.remove(cls));
+    select.value = "";
+  }
   resetGame();
 }
 


### PR DESCRIPTION
## Summary
- Clear the saved theme and reset theme dropdown when clearing game data
- Remove existing theme classes from the page so the default theme is restored

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a4edbb20832ba6a0c1a6404bb930