### PR TITLE
Add playstyle and focus questions

### DIFF
--- a/questions.json
+++ b/questions.json
@@ -1,7 +1,9 @@
 {
   "questions": [
     { "id": "genre", "text": "Preferred genre?", "answers": ["Fantasy", "Sci-Fi", "Mystery"] },
-    { "id": "tone", "text": "Tone?", "answers": ["Light-hearted", "Serious"] },
-    { "id": "length", "text": "Desired length?", "answers": ["Short", "Medium", "Long"] }
+    { "id": "tone", "text": "Preferred tone?", "answers": ["Light-hearted", "Serious"] },
+    { "id": "length", "text": "Desired length?", "answers": ["Short", "Medium", "Long"] },
+    { "id": "playstyle", "text": "Preferred playstyle?", "answers": ["Casual", "Strategic", "Narrative"] },
+    { "id": "focus", "text": "Main story focus?", "answers": ["Character", "Plot", "World"] }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace `questions.json` with a new version containing five questions: genre, tone, length, playstyle, and focus

## Testing
- `node <<'NODE'
const fs = require('fs');
const data = JSON.parse(fs.readFileSync('questions.json', 'utf8'));
console.log('IDs order:', data.questions.map(q => q.id));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b747126fc8832b9ae6b3520d50abc7