### PR TITLE
Default to dark theme and document theme options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ An experimental **choose your own adventure** engine for the browser. The game i
 completely data‑driven – story content, player preferences and world state are
 expressed as JSON that is loaded at runtime.
 
+## Themes
+
+The interface supports multiple color themes that can be selected from the
+dropdown in the UI:
+
+- **Dark** (default)
+- **Moss**
+- **Autumn**
+
+If no theme has been chosen, the dark theme is applied automatically.
+
 ## Stats
 
 Player state is tracked through a simple stats object. Typical fields include

--- a/theme.js
+++ b/theme.js
@@ -55,7 +55,7 @@ function populateThemeDropdown() {
     select.appendChild(option);
   });
 
-  const savedTheme = localStorage.getItem('theme') || '';
+  const savedTheme = localStorage.getItem('theme') || 'theme-dark';
   applyTheme(savedTheme);
   select.value = savedTheme;
 
@@ -65,6 +65,8 @@ function populateThemeDropdown() {
     localStorage.setItem('theme', theme);
   });
 }
+
+document.body.classList.add('theme-dark');
 
 if (document.readyState === 'complete') {
   populateThemeDropdown();


### PR DESCRIPTION
## Summary
- Apply `theme-dark` class to the page by default and use it as the fallback when no theme is saved
- Document available themes and highlight the dark default in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7656f0bc4832b83271d7d7c7d8ec6